### PR TITLE
More dnd styling

### DIFF
--- a/src/components/Card/Card.scss
+++ b/src/components/Card/Card.scss
@@ -7,10 +7,16 @@
     padding: 10px;
 }
 
-.card > img {
+.drag-ref {
+    display: flex;
+    flex-direction: column;
+}
+
+.drag-ref > img {
     width: 220px;
     height: 115px;
     object-fit: cover;
+    border-radius: 15px;
 }
 
 .plant-name {

--- a/src/components/Card/Card.tsx
+++ b/src/components/Card/Card.tsx
@@ -34,8 +34,10 @@ const Card = ({plant}: CardProps) => {
         })
     })
 
+    const draggedCardStyle = isDragging && {opacity: '.4'}
+
     return (
-        <div className='card' style={{opacity: isDragging ? '.4' : 0}}>
+        <div className='card' style={{...draggedCardStyle}}>
             <div className='drag-ref' ref={dragRef}>
                 <img src={plant.image} alt={`${plant.name}`}/>
                 <p className='plant-name'>{plant.name.toUpperCase()}</p>

--- a/src/components/Card/Card.tsx
+++ b/src/components/Card/Card.tsx
@@ -34,10 +34,8 @@ const Card = ({plant}: CardProps) => {
         })
     })
 
-    const draggedCardStyle = isDragging && {opacity: '.4'}
-
     return (
-        <div className='card' style={{...draggedCardStyle}}>
+        <div className='card' style={{opacity: isDragging ? '.4' : 0}}>
             <div className='drag-ref' ref={dragRef}>
                 <img src={plant.image} alt={`${plant.name}`}/>
                 <p className='plant-name'>{plant.name.toUpperCase()}</p>

--- a/src/components/Card/Card.tsx
+++ b/src/components/Card/Card.tsx
@@ -37,9 +37,11 @@ const Card = ({plant}: CardProps) => {
     const draggedCardStyle = isDragging && {opacity: '.4'}
 
     return (
-        <div className='card' style={{...draggedCardStyle}} ref={dragRef}>
-            <img src={plant.image} alt={`${plant.name}`} />
-            <p className='plant-name'>{plant.name.toUpperCase()}</p>
+        <div className='card' style={{...draggedCardStyle}}>
+            <div className='drag-ref' ref={dragRef}>
+                <img src={plant.image} alt={`${plant.name}`}/>
+                <p className='plant-name'>{plant.name.toUpperCase()}</p>
+            </div>
             <div className='card-icons-container'>
                 <div className='card-icons'>
                     <div className="material-symbols-rounded card-icon">

--- a/src/components/Card/Card.tsx
+++ b/src/components/Card/Card.tsx
@@ -34,10 +34,10 @@ const Card = ({plant}: CardProps) => {
         })
     })
 
-    const draggedCardStyle = isDragging && {opacity: '.4'}
+    const draggedCardStyle = isDragging ? {opacity: '.4'} : {}
 
     return (
-        <div className='card' style={{...draggedCardStyle}}>
+        <div className='card' style={draggedCardStyle}>
             <div className='drag-ref' ref={dragRef}>
                 <img src={plant.image} alt={`${plant.name}`}/>
                 <p className='plant-name'>{plant.name.toUpperCase()}</p>

--- a/src/components/Card/Card.tsx
+++ b/src/components/Card/Card.tsx
@@ -34,8 +34,10 @@ const Card = ({plant}: CardProps) => {
         })
     })
 
+    const draggedCardStyle = isDragging && {opacity: '.4'}
+
     return (
-        <div className='card' ref={dragRef}>
+        <div className='card' style={{...draggedCardStyle}} ref={dragRef}>
             <img src={plant.image} alt={`${plant.name}`} />
             <p className='plant-name'>{plant.name.toUpperCase()}</p>
             <div className='card-icons-container'>

--- a/src/components/Cell/Cell.scss
+++ b/src/components/Cell/Cell.scss
@@ -3,8 +3,8 @@
     border-radius: 5px;
     border: solid white 3px;
     margin: 10px;
-    height: 2.8em;
-    width: 2.8em;
+    height: 2.5em;
+    width: 2.5em;
     &:not(.disabled):hover {
         transform: scale(1.3);
     }

--- a/src/components/Cell/Cell.tsx
+++ b/src/components/Cell/Cell.tsx
@@ -37,7 +37,10 @@ const Cell = ({id, toggleModal}: GridCell) => {
         }
     }
 
-    const hoverStyle = isOver && !isDisabled && {transform: 'scale(1.3)'}
+    const hoverStyle = isOver && !isDisabled && {
+        transform: 'scale(1.3)',
+        backgroundColor: 'LawnGreen'
+    }
 
     const divStyle = {
         backgroundImage: `url(${cellContents?.plant.image})`,

--- a/src/components/Cell/Cell.tsx
+++ b/src/components/Cell/Cell.tsx
@@ -46,7 +46,7 @@ const Cell = ({id, toggleModal}: GridCell) => {
     };
 
     return (
-        <div id={id} className='cell' style={Object.assign(divStyle, hoverStyle)} onClick={handleClick} ref={dropRef}></div>
+        <div id={id} className='cell' style={{...divStyle, ...hoverStyle}} onClick={handleClick} ref={dropRef}></div>
     )
 }
 

--- a/src/components/Cell/Cell.tsx
+++ b/src/components/Cell/Cell.tsx
@@ -37,6 +37,8 @@ const Cell = ({id, toggleModal}: GridCell) => {
         }
     }
 
+    const hoverStyle = isOver && !isDisabled && {transform: 'scale(1.3)'}
+
     const divStyle = {
         backgroundImage: `url(${cellContents?.plant.image})`,
         backgroundPosition: 'center',
@@ -44,7 +46,7 @@ const Cell = ({id, toggleModal}: GridCell) => {
     };
 
     return (
-        <div id={id} className='cell' style={divStyle} onClick={handleClick} ref={dropRef}></div>
+        <div id={id} className='cell' style={Object.assign(divStyle, hoverStyle)} onClick={handleClick} ref={dropRef}></div>
     )
 }
 

--- a/src/components/Grid/Grid.scss
+++ b/src/components/Grid/Grid.scss
@@ -4,6 +4,8 @@
     background-color: #beab95;
     height: calc(100vh - 125px);
     width: calc(100vh - 125px);
+    min-height: 658px;
+    min-width: 658px;
     border-radius: 15px;
     flex-shrink: 0;
 }

--- a/src/components/Sidebar/Sidebar.scss
+++ b/src/components/Sidebar/Sidebar.scss
@@ -1,5 +1,6 @@
 #plants {
     height: calc(100vh - 125px);
+    min-height: 658px;
     width: 260px;
     flex-shrink: 0;
     background-color: #beab95;


### PR DESCRIPTION
## What I did:
Made it so Cells scale up and turn green when dnd is active hover over top.
Better sized grid so cells fit again.
Circle should be green again with these changes.

It turns out its pretty difficult to style the dragPreview, so I made a new div for just the pic and name and made that the ref.
Lemme know if you do/don't prefer that over what it was before, or if you have any other ideas how to make it nicer.

## Did this break anything?
- [ ] No
- [ ] Yes

## Type of change

- [ ] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor(DRY-ing up/ reorganizing code, etc.)
- [ ] Super small fix (Corrected a typo, removed a comment, etc.)
- [ ] Skip all the other stuff and briefly explain the fix.

## Checklist:
- [ ] If this code needs to be tested, all tests are passing
- [ ] The code runs locally
- [ ] There are comments where clarification/ organization is needed
- [ ] The code is DRY. If it's not, I tried my best
- [ ] I reviewed my code before pushing

## What's next?
