### PR TITLE
Feature/connect grid to be

### DIFF
--- a/src/apiCalls.tsx
+++ b/src/apiCalls.tsx
@@ -34,7 +34,21 @@ const getPlantDetails = (id: string | undefined) => {
     .then(res => handleError(res))
 }
 
-const patchCellContents = ({plant}: CellContents, id: string) => {
+export type StatusType = {
+  'empty': number
+  'placed': number
+  'disabled': number
+  'locked': number
+}
+
+const STATUS_MAP: StatusType = {
+  'empty': 0,
+  'placed': 1,
+  'disabled': 2,
+  'locked': 3
+}
+
+const patchCellContents = ({plant}: CellContents, id: string, status: keyof StatusType) => {
   console.log(plant)
   return fetch(`https://backyarder-be-47454958a7d2.herokuapp.com/api/v1/cell`, {
             method: 'PATCH',
@@ -42,7 +56,7 @@ const patchCellContents = ({plant}: CellContents, id: string) => {
               plant_name: plant.name,
               location_id: id,
               image: plant.image,
-              status: 1,
+              status: STATUS_MAP[`${status}`],
               plant_id: plant.plant_id
             }),
             headers: {

--- a/src/apiCalls.tsx
+++ b/src/apiCalls.tsx
@@ -49,7 +49,7 @@ const STATUS_MAP: StatusType = {
 }
 
 const patchCellContents = ({plant}: CellContents, id: string, status: keyof StatusType) => {
-  console.log(plant)
+  console.log(status)
   return fetch(`https://backyarder-be-47454958a7d2.herokuapp.com/api/v1/cell`, {
             method: 'PATCH',
             body: JSON.stringify({
@@ -66,4 +66,22 @@ const patchCellContents = ({plant}: CellContents, id: string, status: keyof Stat
           .then(res => handleError(res))
 }
 
-export { getPlantList, getGarden, searchPlants, getPlantDetails, patchCellContents }
+const patchDisabledOrRemoved = (id: string, status: keyof StatusType) => {
+  console.log(status)
+  return fetch(`https://backyarder-be-47454958a7d2.herokuapp.com/api/v1/cell`, {
+            method: 'PATCH',
+            body: JSON.stringify({
+              plant_name: null,
+              location_id: id,
+              image: null,
+              status: STATUS_MAP[`${status}`],
+              plant_id: null
+            }),
+            headers: {
+              'Content-Type': 'application/json'
+            }
+          })
+          .then(res => handleError(res))
+}
+
+export { getPlantList, getGarden, searchPlants, getPlantDetails, patchCellContents, patchDisabledOrRemoved }

--- a/src/apiCalls.tsx
+++ b/src/apiCalls.tsx
@@ -4,7 +4,6 @@ const handleError = (res: Response) => {
     if(!res.ok) {
       throw new Error(`HTTP Error: ${res.status} -- Please try again later`)
     }
-    console.log(res)
     return res.json()
   }
 
@@ -92,7 +91,6 @@ const deleteContents = (path: string, setter: Function) => {
       if (!res.ok) {
         throw new Error('Unable to clear garden');
       }
-      console.log(res);
       setter(true);
       alert('Garden cleared.');
     })

--- a/src/apiCalls.tsx
+++ b/src/apiCalls.tsx
@@ -4,14 +4,20 @@ const handleError = (res: Response) => {
     if(!res.ok) {
       throw new Error(`HTTP Error: ${res.status} -- Please try again later`)
     }
+    console.log(res)
     return res.json()
   }
 
 const getPlantList = () => {
     return fetch(`https://backyarder-be-47454958a7d2.herokuapp.com/api/v1/plants`, {
-        cache: 'force-cache',
+      cache: 'force-cache',
     })
-        .then(res => handleError(res))
+      .then(res => handleError(res))
+}
+
+const getGarden = () => {
+    return fetch(`https://backyarder-be-47454958a7d2.herokuapp.com/api/v1/garden`)
+      .then(res => handleError(res))
 }
 
 const searchPlants = (searchterm: string) => {
@@ -29,6 +35,7 @@ const getPlantDetails = (id: string | undefined) => {
 }
 
 const patchCellContents = ({plant}: CellContents, id: string) => {
+  console.log(plant)
   return fetch(`https://backyarder-be-47454958a7d2.herokuapp.com/api/v1/cell`, {
             method: 'PATCH',
             body: JSON.stringify({
@@ -45,4 +52,4 @@ const patchCellContents = ({plant}: CellContents, id: string) => {
           .then(res => handleError(res))
 }
 
-export { getPlantList, searchPlants, getPlantDetails, patchCellContents }
+export { getPlantList, getGarden, searchPlants, getPlantDetails, patchCellContents }

--- a/src/components/Cell/Cell.tsx
+++ b/src/components/Cell/Cell.tsx
@@ -4,7 +4,7 @@ import CellActions from '../CellActions/CellActions';
 import { CellKeys, GridProps } from '../Grid/Grid';
 import { GardenKeys } from '../Main/Main';
 import { patchCellContents } from '../../apiCalls';
-import { cellIDs } from '../Grid/cellIDs';
+import { StatusType } from '../../apiCalls';
 import './Cell.scss'
 
 interface GridCell extends GridProps {
@@ -26,12 +26,11 @@ const Cell = ({ id, garden, setGarden, bullDoze, setBullDoze, filterGarden, setF
   const [isPlanted, setIsPlanted] = useState<boolean>(false);
   // eslint-disable-next-line
   const [apiError, setApiError] = useState<string>('')
-  const [needsUpdate, setNeedsUpdate] = useState<boolean>(false)
+  const [needsUpdate, setNeedsUpdate] = useState<(keyof StatusType)>()
 
   useEffect(() => {
     if(cellContents && needsUpdate) {
-      setNeedsUpdate(false)
-      patchCellContents(cellContents, id)
+      patchCellContents(cellContents, id, needsUpdate)
       .catch((err) => {
           handleApiError(err)
       })
@@ -142,7 +141,7 @@ const Cell = ({ id, garden, setGarden, bullDoze, setBullDoze, filterGarden, setF
         toggleModal()
       } else {
         setCellContents(plant)
-        setNeedsUpdate(true)
+        setNeedsUpdate('placed')
         setIsPopulated(true)
       }
     },
@@ -162,6 +161,10 @@ const Cell = ({ id, garden, setGarden, bullDoze, setBullDoze, filterGarden, setF
 
   const handleCloseModal = () => {
     setIsClicked(false)
+  }
+
+  const handleNeedsUpdating = (status: keyof StatusType) => {
+    setNeedsUpdate(status)
   }
 
   const handleClick = (e: React.MouseEvent) => {
@@ -208,7 +211,15 @@ const Cell = ({ id, garden, setGarden, bullDoze, setBullDoze, filterGarden, setF
       {isPopulated ? (
         <div id={id} className={className} style={{ ...divStyle, ...hoverStyle }} onClick={handleClick} ref={dropRef}>
           {isClicked && <div className='cell-modal'>
-            {cellContents && <CellActions image={cellContents.plant.image} name={cellContents.plant.name} plantId={cellContents.plant.plant_id} handlePlanted={handlePlanted} handleRemove={handleRemove} handleCloseModal={handleCloseModal} />}
+            {cellContents && <CellActions 
+                                image={cellContents.plant.image}
+                                name={cellContents.plant.name}
+                                plantId={cellContents.plant.plant_id}
+                                handlePlanted={handlePlanted}
+                                handleRemove={handleRemove}
+                                handleCloseModal={handleCloseModal}
+                                handleNeedsUpdating={handleNeedsUpdating}
+                              />}
           </div>}
         </div>
       ) : (

--- a/src/components/Cell/Cell.tsx
+++ b/src/components/Cell/Cell.tsx
@@ -74,37 +74,6 @@ const Cell = ({ id, garden, setGarden, bullDoze, setBullDoze, filterGarden, setF
     // eslint-disable-next-line
   }, []);
 
-  // NOTE: make sure to refactor this to only update the single cell data instead of updating the entire garden state
-  // useEffect(() => {
-  //   setGarden((prevState: GardenKeys) => {
-  //     let index = prevState?.findIndex((item) => item.id === cell?.id);
-  //     let newState = [...prevState];
-  //     newState[index] = {
-  //       ...newState[index],
-  //       status: Number(isDisabled)
-  //     };
-  //     return newState;
-  //   });
-  //   // eslint-disable-next-line
-  // }, [isDisabled]);
-
-  // NOTE: make sure to refactor this to only update the single cell data instead of updating the entire garden state
-  // useEffect(() => {
-  //   setGarden((prevState: GardenKeys) => {
-  //     let index = prevState?.findIndex((item) => item.id === cell?.id);
-  //     let newState = [...prevState];
-  //     newState[index] = {
-  //       ...newState[index],
-  //       image: cellContents?.plant.image,
-  //       name: cellContents?.plant.name,
-  //       'plant_id': cellContents?.plant.plant_id
-  //     };
-  //     return newState;
-  //   });
-  //   // eslint-disable-next-line
-  // }, [isPlanted]);
-
-  // NOTE: likely all we need to do for this one is trigger a re-render on the useEffect we run on page load. Check it out when you're hooking this functionality into the BE.
   useEffect(() => {
     if (bullDoze) {
       setClassName('cell');
@@ -126,7 +95,6 @@ const Cell = ({ id, garden, setGarden, bullDoze, setBullDoze, filterGarden, setF
     // eslint-disable-next-line
   }, [bullDoze])
 
-  // NOTE: likely all we need to do for this one is trigger a re-render on the useEffect we run on page load. Check it out when you're hooking this functionality into the BE.
   useEffect(() => {
     if (filterGarden && !isPlanted) {
       unPlantItems();

--- a/src/components/Cell/Cell.tsx
+++ b/src/components/Cell/Cell.tsx
@@ -3,7 +3,7 @@ import { useDrop } from 'react-dnd';
 import CellActions from '../CellActions/CellActions';
 import { CellKeys, GridProps } from '../Grid/Grid';
 import { GardenKeys } from '../Main/Main';
-import { patchCellContents } from '../../apiCalls';
+import { patchCellContents, patchDisabledOrRemoved } from '../../apiCalls';
 import { StatusType } from '../../apiCalls';
 import './Cell.scss'
 
@@ -37,6 +37,16 @@ const Cell = ({ id, garden, setGarden, bullDoze, setBullDoze, filterGarden, setF
     }
     // eslint-disable-next-line
   }, [needsUpdate])
+
+  useEffect(() => {
+    if(needsUpdate) {
+      patchDisabledOrRemoved(id, needsUpdate)
+      .catch((err) => {
+          handleApiError(err)
+      })
+    }
+    // eslint-disable-next-line
+  }, [isDisabled, cellContents === undefined])
 
   const handleApiError = (error: string) => {
     setApiError(error)
@@ -157,6 +167,7 @@ const Cell = ({ id, garden, setGarden, bullDoze, setBullDoze, filterGarden, setF
   const handleRemove = () => {
     setIsPlanted(false)
     setCellContents(undefined)
+    handleNeedsUpdating('empty')
   }
 
   const handleCloseModal = () => {
@@ -172,6 +183,7 @@ const Cell = ({ id, garden, setGarden, bullDoze, setBullDoze, filterGarden, setF
     if (!cellContents) {
       setIsDisabled(!isDisabled)
       !isDisabled ? setClassName('cell disabled') : setClassName('cell');
+      !isDisabled ? setNeedsUpdate('disabled') : setNeedsUpdate('empty')
     } else {
       setIsClicked(true)
       target.classList.add('disable-scale')

--- a/src/components/Cell/Cell.tsx
+++ b/src/components/Cell/Cell.tsx
@@ -31,6 +31,7 @@ const Cell = ({ id, garden, setGarden, bullDoze, setBullDoze, filterGarden, setF
   useEffect(() => {
     if(cellContents && needsUpdate) {
       patchCellContents(cellContents, id, needsUpdate)
+      .then(data => console.log(data))
       .catch((err) => {
           handleApiError(err)
       })
@@ -70,6 +71,7 @@ const Cell = ({ id, garden, setGarden, bullDoze, setBullDoze, filterGarden, setF
       }
       setCell(foundCell);
     }
+    // eslint-disable-next-line
   }, []);
 
   // NOTE: make sure to refactor this to only update the single cell data instead of updating the entire garden state
@@ -151,8 +153,10 @@ const Cell = ({ id, garden, setGarden, bullDoze, setBullDoze, filterGarden, setF
         toggleModal()
       } else {
         setCellContents(plant)
-        setNeedsUpdate('placed')
-        setIsPopulated(true)
+        setTimeout(() => {
+          setNeedsUpdate('placed')
+          setIsPopulated(true)
+        }, 0)
       }
     },
     collect: (monitor) => ({

--- a/src/components/Cell/Cell.tsx
+++ b/src/components/Cell/Cell.tsx
@@ -31,7 +31,6 @@ const Cell = ({ id, garden, setGarden, bullDoze, setBullDoze, filterGarden, setF
   useEffect(() => {
     if(cellContents && needsUpdate) {
       patchCellContents(cellContents, id, needsUpdate)
-      .then(data => console.log(data))
       .catch((err) => {
           handleApiError(err)
       })

--- a/src/components/CellActions/CellActions.tsx
+++ b/src/components/CellActions/CellActions.tsx
@@ -8,15 +8,17 @@ interface CellProps {
     handleCloseModal: () => void
     handlePlanted: () => void
     handleRemove: () => void
+    handleNeedsUpdating: Function
 }
 
-const CellActions = ({ image, name, plantId, handleCloseModal, handlePlanted, handleRemove }: CellProps) => {
+const CellActions = ({ image, name, plantId, handleCloseModal, handlePlanted, handleRemove, handleNeedsUpdating }: CellProps) => {
 
     const handleClick = (e: React.MouseEvent) => {
         e.stopPropagation()
         const target = e.target as Element
         if (target.classList.contains('plant-button')) {
             handlePlanted()
+            handleNeedsUpdating('locked')
         } else if (target.classList.contains('remove-button')) {
             handleRemove()
         }

--- a/src/components/Grid/Grid.tsx
+++ b/src/components/Grid/Grid.tsx
@@ -2,6 +2,7 @@ import { useState } from 'react';
 import Cell from '../Cell/Cell';
 import Modal from '../Modal/Modal';
 import { GardenKeys } from '../Main/Main';
+import { cellIDs } from './cellIDs';
 import './Grid.scss';
 
 export interface GridProps {
@@ -14,11 +15,11 @@ export interface GridProps {
 }
 
 export type CellKeys = {
-  id: string;
+  location_id: string;
   image: string | undefined;
   name: string | undefined;
   plant_id: number | undefined;
-  status: number | null;
+  status: string | number | null;
 }
 
 const Grid = ({ garden, setGarden, bullDoze, setBullDoze, filterGarden, setFilterGarden }: GridProps) => {
@@ -28,11 +29,11 @@ const Grid = ({ garden, setGarden, bullDoze, setBullDoze, filterGarden, setFilte
     setModal(!modal);
   }
 
-  const cells = garden?.map(cell => {
+  const cells = garden?.map((cell, i) => {
     return (
       <Cell
-        key={cell.id}
-        id={cell.id}
+        key={cell.location_id}
+        id={cellIDs[i].id}
         garden={garden}
         setGarden={setGarden}
         bullDoze={bullDoze}

--- a/src/components/Main/Main.tsx
+++ b/src/components/Main/Main.tsx
@@ -4,20 +4,40 @@ import Nav from '../Nav/Nav';
 import List from '../List/List';
 import { useEffect, useState } from 'react';
 import { cellIDs } from '../Grid/cellIDs';
+import { getGarden } from '../../apiCalls';
 import './Main.scss';
 
 export type GardenKeys = CellKeys[];
+
+type GetGardenKeys = {
+  id: number
+  type: string
+  attributes: CellKeys[]
+}
 
 const Main = () => {
   const [garden, setGarden] = useState<GardenKeys | undefined>([]);
   const [isGardenView, setIsGardenView] = useState<boolean>(true);
   const [bullDoze, setBullDoze] = useState<boolean>(false);
   const [filterGarden, setFilterGarden] = useState<boolean>(false);
+  // eslint-disable-next-line
+  const [apiError, setApiError] = useState<string>('')
 
   // NOTE: will be updated with BE data next!
   useEffect(() => {
-    setGarden(cellIDs);
+    getGarden()
+      .then(data => {
+        const cellData = data.data.map((cellData: GetGardenKeys) => cellData.attributes)
+        setGarden(cellData)
+      })
+      .catch((err) => {
+        handleApiError(err)
+      })
   }, []);
+
+  const handleApiError = (error: string) => {
+    setApiError(error)
+  }
 
   return (
     <main>

--- a/src/components/Main/Main.tsx
+++ b/src/components/Main/Main.tsx
@@ -3,7 +3,6 @@ import Grid, { CellKeys } from '../Grid/Grid';
 import Nav from '../Nav/Nav';
 import List from '../List/List';
 import { useEffect, useState } from 'react';
-import { cellIDs } from '../Grid/cellIDs';
 import { getGarden } from '../../apiCalls';
 import './Main.scss';
 

--- a/src/components/Main/Main.tsx
+++ b/src/components/Main/Main.tsx
@@ -22,7 +22,6 @@ const Main = () => {
   // eslint-disable-next-line
   const [apiError, setApiError] = useState<string>('')
 
-  // NOTE: will be updated with BE data next!
   useEffect(() => {
     getGarden()
       .then(data => {


### PR DESCRIPTION
## What I did:
Connect all Grid actions to BE!!!
- On page load now populates ALL backend data onto the grid
- Grid actions that send PATCH data back to BE
  - Empty Cell / Undisable Cell (status: 0, 'empty')
  - Disable (status: 1, 'disabled')
  - Add plant to Cell (status: 2, 'placed')
  - Plant item (status: 3, 'locked')

Testing Notes:
- Important: ENSURE all plants / disabled cell data persists on page load as expected!!!
   - there was a nasty bug where `setCellContents` did not update its state before continuing to update the FE
   - setting an empty `setTimeout` seems to have resolved it

## Did this break anything?
- [ ] No
- [ ] Yes

## Type of change

- [ ] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor(DRY-ing up/ reorganizing code, etc.)
- [ ] Super small fix (Corrected a typo, removed a comment, etc.)
- [ ] Skip all the other stuff and briefly explain the fix.

## Checklist:
- [ ] If this code needs to be tested, all tests are passing
- [ ] The code runs locally
- [ ] There are comments where clarification/ organization is needed
- [ ] The code is DRY. If it's not, I tried my best
- [ ] I reviewed my code before pushing

## What's next?
