### PR TITLE
Make small screens unavailable onload

### DIFF
--- a/cypress.config.ts
+++ b/cypress.config.ts
@@ -1,6 +1,7 @@
 import { defineConfig } from "cypress";
 
 export default defineConfig({
+  viewportWidth: 1049,
   e2e: {
     setupNodeEvents(on, config) {
       // implement node event listeners here

--- a/src/components/Main/Main.scss
+++ b/src/components/Main/Main.scss
@@ -14,3 +14,9 @@ main {
   border-radius: 1em;
   margin: 1em;
 }
+
+@media (max-width: 1048px) {
+  .mobile-message {
+    display: block; /* Show this message on small screens */
+  }
+}

--- a/src/components/Main/Main.tsx
+++ b/src/components/Main/Main.tsx
@@ -23,15 +23,21 @@ const Main = () => {
   // eslint-disable-next-line
   const [apiError, setApiError] = useState<string>('')
 
-  const updateMedia = () => {
-    setIsDesktop(window.innerWidth > 1048);
-  };
-
   useEffect(() => {
-    const checkScreenSize = () => setIsDesktop(window.innerWidth > 1048)
-    checkScreenSize()
-    window.addEventListener('resize', checkScreenSize)
-    return () => window.removeEventListener('resize', checkScreenSize)
+    const checkScreenSize = () => {
+      setIsDesktop(window.innerWidth > 1048);
+    };
+
+    // Check screen size on page load
+    checkScreenSize();
+
+    // Attach event listener to update screen size on resize
+    window.addEventListener('resize', checkScreenSize);
+
+    // Remove event listener when the component unmounts
+    return () => {
+      window.removeEventListener('resize', checkScreenSize);
+    };
   }, []);
 
   useEffect(() => {

--- a/src/components/Main/Main.tsx
+++ b/src/components/Main/Main.tsx
@@ -28,9 +28,11 @@ const Main = () => {
   };
 
   useEffect(() => {
-    window.addEventListener("resize", updateMedia);
-    return () => window.removeEventListener("resize", updateMedia);
-  });
+    const checkScreenSize = () => setIsDesktop(window.innerWidth > 1048)
+    checkScreenSize()
+    window.addEventListener('resize', checkScreenSize)
+    return () => window.removeEventListener('resize', checkScreenSize)
+  }, []);
 
   useEffect(() => {
     getGarden()
@@ -63,7 +65,9 @@ const Main = () => {
               {isGardenView ? <Grid garden={garden} setGarden={setGarden} bullDoze={bullDoze} setBullDoze={setBullDoze} filterGarden={filterGarden} setFilterGarden={setFilterGarden} /> : <List garden={garden} />}
               <Nav isGardenView={isGardenView} setIsGardenView={setIsGardenView} setBullDoze={setBullDoze} setFilterGarden={setFilterGarden} />
             </>
-            : 'Please switch to a larger device to use this app'
+            : <div className="mobile-message">
+                Please switch to a larger device to use this app.
+              </div>
           }
         </main>
       )}

--- a/src/components/Main/Main.tsx
+++ b/src/components/Main/Main.tsx
@@ -25,7 +25,7 @@ const Main = () => {
 
   useEffect(() => {
     const checkScreenSize = () => {
-      setIsDesktop(window.innerWidth > 1048);
+      setIsDesktop(window.innerWidth > 1048 && window.innerHeight > 600);
     };
 
     // Check screen size on page load


### PR DESCRIPTION
## What I did:
Make small screens unavailable onload.
NOTE: If you start a device in landscape mode, then switch to portrait mode it looks like it will display again ugh

### Testing notes:
- Use chrome dev-tools device toolbar to check various devices
  - anything less than 1048px wide onload should render the message

## Did this break anything?
- [ ] No
- [ ] Yes

## Type of change

- [ ] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor(DRY-ing up/ reorganizing code, etc.)
- [ ] Super small fix (Corrected a typo, removed a comment, etc.)
- [ ] Skip all the other stuff and briefly explain the fix.

## Checklist:
- [ ] If this code needs to be tested, all tests are passing
- [ ] The code runs locally
- [ ] There are comments where clarification/ organization is needed
- [ ] The code is DRY. If it's not, I tried my best
- [ ] I reviewed my code before pushing

## What's next?
