### PR TITLE
Fix removing disabled cell status on modal close

### DIFF
--- a/src/components/Cell/Cell.tsx
+++ b/src/components/Cell/Cell.tsx
@@ -113,7 +113,7 @@ const Cell = ({ id, garden, setGarden, bullDoze, setBullDoze, filterGarden, setF
   const [{ isOver }, dropRef] = useDrop({
     accept: 'plant',
     drop: (plant: CellContents) => {
-      if (isDisabled) {
+      if (isDisabled || isPlanted) {
         toggleModal();
       } else {
         setCellContents(plant);

--- a/src/components/CellActions/CellActions.tsx
+++ b/src/components/CellActions/CellActions.tsx
@@ -22,7 +22,7 @@ const CellActions = ({ image, name, plantId, handleCloseModal, handlePlanted, ha
         } else if (target.classList.contains('remove-button')) {
             handleRemove()
         }
-        const cell = target.closest('disable-scale')
+        const cell = target.closest('.disable-scale')
         cell?.classList.remove('disable-scale')
         const grid = target.closest('#grid')
         grid?.classList.remove('disable-hover')


### PR DESCRIPTION
## What I did:
One-character fix to remove `.disable-scale` when cell action modal close haha.
Also prevent drag-and-drop onto planted cells.

### Testing notes:
- After closing a CellAction modal, the parent cell should get back it hover effects
- User is now prevented from drag-and-dropping onto a planted cell.
  - Ensure prevention of the same onto a disabled cell
  - Dragging and dropping onto empty and placed cell should still work

## Did this break anything?
- [ ] No
- [ ] Yes

## Type of change

- [ ] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor(DRY-ing up/ reorganizing code, etc.)
- [ ] Super small fix (Corrected a typo, removed a comment, etc.)
- [ ] Skip all the other stuff and briefly explain the fix.

## Checklist:
- [ ] If this code needs to be tested, all tests are passing
- [ ] The code runs locally
- [ ] There are comments where clarification/ organization is needed
- [ ] The code is DRY. If it's not, I tried my best
- [ ] I reviewed my code before pushing

## What's next?
