### PR TITLE
Add initial watering logic

### DIFF
--- a/src/apiCalls.tsx
+++ b/src/apiCalls.tsx
@@ -9,7 +9,7 @@ const handleError = (res: Response) => {
 
 const getPlantList = () => {
     return fetch(`https://backyarder-be-47454958a7d2.herokuapp.com/api/v1/plants`, {
-      cache: 'force-cache',
+      // cache: 'force-cache',
     })
       .then(res => handleError(res))
 }
@@ -21,7 +21,7 @@ const getGarden = () => {
 
 const searchPlants = (searchterm: string) => {
   return fetch(`https://backyarder-be-47454958a7d2.herokuapp.com/api/v1/search/${searchterm}`, {
-    cache: 'force-cache'
+    // cache: 'force-cache'
   })
     .then(res => handleError(res))
 }
@@ -47,7 +47,21 @@ const STATUS_MAP: StatusType = {
   'locked': 3
 }
 
-const patchCellContents = ({plant}: CellContents, id: string, status: keyof StatusType) => {
+export type WateringType = {
+  'None': number | undefined
+  'Minimum': number | undefined
+  'Average': number | undefined
+  'Frequent': number | undefined
+}
+
+const WATERING_MAP: WateringType = {
+  'None': 0,
+  'Minimum': 1,
+  'Average': 2,
+  'Frequent': 3
+}
+
+const patchCellContents = ({plant}: CellContents, id: string, status: keyof StatusType, watering: keyof WateringType) => {
   return fetch(`https://backyarder-be-47454958a7d2.herokuapp.com/api/v1/cell`, {
             method: 'PATCH',
             body: JSON.stringify({
@@ -55,6 +69,7 @@ const patchCellContents = ({plant}: CellContents, id: string, status: keyof Stat
               location_id: id,
               image: plant.image,
               status: STATUS_MAP[`${status}`],
+              watering: WATERING_MAP[`${watering}`],
               plant_id: plant.plant_id
             }),
             headers: {

--- a/src/components/Cell/Cell.tsx
+++ b/src/components/Cell/Cell.tsx
@@ -15,6 +15,18 @@ export interface CellContents {
   plant: CellKeys;
 }
 
+// const WATERING_SCHEDULE = {
+//   'Minimum': 7,
+//   'Average': 3,
+//   'Frequent': 1
+// }
+
+const WATERING_SCHEDULE = {
+  'Minimum': 1 / (24),           // 1hr
+  'Average': 1 / (24 * 60),      // 1min
+  'Frequent': 1 / (24 * 60 * 60) // 1sec
+}
+
 const Cell = ({ id, garden, setGarden, bullDoze, setBullDoze, filterGarden, setFilterGarden, toggleModal }: GridCell) => {
   // eslint-disable-next-line
   const [apiError, setApiError] = useState<string>('');
@@ -36,7 +48,6 @@ const Cell = ({ id, garden, setGarden, bullDoze, setBullDoze, filterGarden, setF
   useEffect(() => {
     if (garden) {
       const foundCell = garden.find(cell => cell.location_id === id);
-      console.log(id)
       if (foundCell?.status === 'placed') {
         setCellContents({ plant: foundCell });
         setIsPopulated(true);
@@ -48,17 +59,28 @@ const Cell = ({ id, garden, setGarden, bullDoze, setBullDoze, filterGarden, setF
         setIsPopulated(true);
         setIsPlanted(true);
       }
-      // if (id === 'H5'){
-      // setNeedsWatering(true) // uncomment to test needsWatering behavior
-      // }
+
       setCell(foundCell);
     }
     // eslint-disable-next-line
   }, []);
 
   useEffect(() => {
+    if (isPlanted && cellContents?.plant.watering && cellContents?.plant.watering !== 'None' && typeof cellContents?.plant.updated_at !== 'undefined') {
+      const today = Date.now() + 14400000  //for some reason I have to add 4 hours to get the correct time
+      const daysToAdd = WATERING_SCHEDULE[cellContents?.plant.watering]
+      const nextWatering = new Date(cellContents?.plant.updated_at).getTime() + (daysToAdd * 24 * 60 * 60 * 1000)
+      console.log(cellContents?.plant.updated_at)
+      console.log(today, nextWatering)
+      if (today > nextWatering) {
+        setNeedsWatering(true);
+      }
+    }
+  }, [cellContents, isPlanted])
+
+  useEffect(() => {
     if (cellContents && needsUpdate) {
-      patchCellContents(cellContents, id, needsUpdate)
+      patchCellContents(cellContents, id, needsUpdate, cellContents?.plant?.watering)
         .catch((err) => {
           handleApiError(err);
         });

--- a/src/components/Cell/Cell.tsx
+++ b/src/components/Cell/Cell.tsx
@@ -27,7 +27,7 @@ const WATERING_SCHEDULE = {
   'Frequent': 1 / (24 * 60 * 60) // 1sec
 }
 
-const Cell = ({ id, garden, setGarden, bullDoze, setBullDoze, filterGarden, setFilterGarden, toggleModal }: GridCell) => {
+const Cell = ({ id, garden, setGarden, waterGarden, bullDoze, setBullDoze, filterGarden, setFilterGarden, toggleModal }: GridCell) => {
   // eslint-disable-next-line
   const [apiError, setApiError] = useState<string>('');
   // eslint-disable-next-line
@@ -37,7 +37,6 @@ const Cell = ({ id, garden, setGarden, bullDoze, setBullDoze, filterGarden, setF
   const [isClicked, setIsClicked] = useState<boolean>(false);
   const [isDisabled, setIsDisabled] = useState<boolean>(false);
   const [isPlanted, setIsPlanted] = useState<boolean>(false);
-  // eslint-disable-next-line
   const [needsWatering, setNeedsWatering] = useState<boolean>(false);
   // eslint-disable-next-line
   const [isWatered, setIsWatered] = useState<boolean>(false);
@@ -77,6 +76,11 @@ const Cell = ({ id, garden, setGarden, bullDoze, setBullDoze, filterGarden, setF
       }
     }
   }, [cellContents, isPlanted])
+
+  useEffect(() => {
+    handleWatered()
+    // eslint-disable-next-line
+  }, [waterGarden])
 
   useEffect(() => {
     if (cellContents && needsUpdate) {

--- a/src/components/Cell/Cell.tsx
+++ b/src/components/Cell/Cell.tsx
@@ -67,11 +67,11 @@ const Cell = ({ id, garden, setGarden, bullDoze, setBullDoze, filterGarden, setF
 
   useEffect(() => {
     if (isPlanted && cellContents?.plant.watering && cellContents?.plant.watering !== 'None' && typeof cellContents?.plant.updated_at !== 'undefined') {
-      const today = Date.now() + 14400000  //for some reason I have to add 4 hours to get the correct time
+      const today = Date.now() + new Date(cellContents?.plant.updated_at).getTimezoneOffset() * 60 * 1000
       const daysToAdd = WATERING_SCHEDULE[cellContents?.plant.watering]
       const nextWatering = new Date(cellContents?.plant.updated_at).getTime() + (daysToAdd * 24 * 60 * 60 * 1000)
-      console.log(cellContents?.plant.updated_at)
-      console.log(today, nextWatering)
+      // console.log(cellContents?.plant.updated_at)
+      // console.log(today, nextWatering)
       if (today > nextWatering) {
         setNeedsWatering(true);
       }

--- a/src/components/Cell/Cell.tsx
+++ b/src/components/Cell/Cell.tsx
@@ -70,8 +70,8 @@ const Cell = ({ id, garden, setGarden, bullDoze, setBullDoze, filterGarden, setF
       const today = Date.now() + new Date(cellContents?.plant.updated_at).getTimezoneOffset() * 60 * 1000
       const daysToAdd = WATERING_SCHEDULE[cellContents?.plant.watering]
       const nextWatering = new Date(cellContents?.plant.updated_at).getTime() + (daysToAdd * 24 * 60 * 60 * 1000)
-      // console.log(cellContents?.plant.updated_at)
-      // console.log(today, nextWatering)
+      console.log(cellContents?.plant.updated_at)
+      console.log(today, nextWatering)
       if (today > nextWatering) {
         setNeedsWatering(true);
       }
@@ -202,8 +202,16 @@ const Cell = ({ id, garden, setGarden, bullDoze, setBullDoze, filterGarden, setF
     setShouldRender(true);
   }
 
-  const handleWatered = () => {
-    setIsWatered(true)
+  const handleWatered = async () => {
+    if (cellContents) {
+      try {
+        await patchCellContents(cellContents, id, 'placed', cellContents?.plant?.watering)
+        await patchCellContents(cellContents, id, 'locked', cellContents?.plant?.watering)
+        setNeedsWatering(false)
+      } catch (err) {
+          handleApiError(err as string)
+      }
+    }
   }
 
   const handleRemove = () => {

--- a/src/components/CellActions/CellActions.scss
+++ b/src/components/CellActions/CellActions.scss
@@ -36,6 +36,6 @@
     border-radius: 1em;
 }
 
-.plant-icon {
+.icon {
     padding-left: 0.3em
 }

--- a/src/components/CellActions/CellActions.tsx
+++ b/src/components/CellActions/CellActions.tsx
@@ -21,7 +21,7 @@ const CellActions = ({ image, name, plantId, handleCloseModal, isPlanted, handle
         if (target.classList.contains('plant-button')) {
             handlePlanted()
             handleNeedsUpdating('locked')
-        } else if (target.classList.contains('water-button')) {
+        } else if (target.classList.contains('water-button') || target.classList.contains('icon')) {
             handleWatered()
         } else if (target.classList.contains('remove-button')) {
             handleRemove()
@@ -41,13 +41,13 @@ const CellActions = ({ image, name, plantId, handleCloseModal, isPlanted, handle
                 {isPlanted
                     ? <button className='cell-button water-button' onClick={handleClick}>
                         Water!
-                        <span className="material-symbols-rounded plant-icon plant-button">
+                        <span className="material-symbols-rounded icon">
                             water_drop
                         </span>
                     </button>
                     : <button className='cell-button plant-button' onClick={handleClick}>
                         Plant!
-                        <span className="material-symbols-rounded plant-icon plant-button">
+                        <span className="material-symbols-rounded icon plant-button">
                             psychiatry
                         </span>
                     </button>

--- a/src/components/Grid/Grid.tsx
+++ b/src/components/Grid/Grid.tsx
@@ -5,6 +5,7 @@ import { GardenKeys } from '../Main/Main';
 import { cellIDs } from './cellIDs';
 import './Grid.scss';
 import ConfirmModal from '../ConfirmModal/ConfirmModal';
+import { WateringType } from '../../apiCalls';
 
 export interface GridProps {
   garden: GardenKeys | undefined;
@@ -35,7 +36,9 @@ export type CellKeys = {
   image: string | undefined;
   plant_name: string | undefined;
   plant_id: number | undefined;
+  watering: keyof WateringType
   status: string | number | null | undefined;
+  updated_at: number | undefined;
 }
 
 const Grid = ({ popUp, setPopUp, fullClear, setFullClear, setPartialClear, reset, alert, setAlert, modal, setModal, garden, setGarden, bullDoze, setBullDoze, filterGarden, setFilterGarden }: CombinedProps) => {
@@ -71,7 +74,7 @@ const Grid = ({ popUp, setPopUp, fullClear, setFullClear, setPartialClear, reset
       />
     );
   });
-
+  console.log(garden)
   return (
     <section id='grid'>
       {cells}

--- a/src/components/Grid/Grid.tsx
+++ b/src/components/Grid/Grid.tsx
@@ -10,6 +10,7 @@ import { WateringType } from '../../apiCalls';
 export interface GridProps {
   garden: GardenKeys | undefined;
   setGarden: Function;
+  waterGarden: boolean;
   bullDoze: boolean;
   setBullDoze: Function;
   filterGarden: boolean;
@@ -41,7 +42,7 @@ export type CellKeys = {
   updated_at: number | undefined;
 }
 
-const Grid = ({ popUp, setPopUp, fullClear, setFullClear, setPartialClear, reset, alert, setAlert, modal, setModal, garden, setGarden, bullDoze, setBullDoze, filterGarden, setFilterGarden }: CombinedProps) => {
+const Grid = ({ popUp, setPopUp, fullClear, setFullClear, setPartialClear, reset, alert, setAlert, modal, setModal, garden, setGarden, waterGarden, bullDoze, setBullDoze, filterGarden, setFilterGarden }: CombinedProps) => {
 
   useEffect(() => {
     if (alert) {
@@ -66,6 +67,7 @@ const Grid = ({ popUp, setPopUp, fullClear, setFullClear, setPartialClear, reset
         id={cellIDs[i].id}
         garden={garden}
         setGarden={setGarden}
+        waterGarden={waterGarden}
         bullDoze={bullDoze}
         setBullDoze={setBullDoze}
         filterGarden={filterGarden}

--- a/src/components/Main/Main.tsx
+++ b/src/components/Main/Main.tsx
@@ -92,7 +92,11 @@ const Main = () => {
           {isDesktop ?
             <>
               <Sidebar modal={modal} setModal={setModal} />
-              {isGardenView ? <Grid popUp={popUp} setPopUp={setPopUp} fullClear={fullClear} setFullClear={setFullClear} setPartialClear={setPartialClear} reset={reset} alert={alert} setAlert={setAlert} modal={modal} setModal={setModal} garden={garden} setGarden={setGarden} bullDoze={bullDoze} setBullDoze={setBullDoze} filterGarden={filterGarden} setFilterGarden={setFilterGarden} /> : <List garden={garden} />}
+              {
+                isGardenView
+                ? <Grid popUp={popUp} setPopUp={setPopUp} fullClear={fullClear} setFullClear={setFullClear} setPartialClear={setPartialClear} reset={reset} alert={alert} setAlert={setAlert} modal={modal} setModal={setModal} garden={garden} setGarden={setGarden} bullDoze={bullDoze} setBullDoze={setBullDoze} filterGarden={filterGarden} setFilterGarden={setFilterGarden} />
+                : <List garden={garden} />
+              }
               <Nav reset={reset} handleFullClear={handleFullClear} handlePartialClear={handlePartialClear} isGardenView={isGardenView} setIsGardenView={setIsGardenView} />
             </>
             : <div className="mobile-message">

--- a/src/components/Main/Main.tsx
+++ b/src/components/Main/Main.tsx
@@ -18,6 +18,7 @@ const Main = () => {
   const [alert, setAlert] = useState<boolean>(false);
   const [modal, setModal] = useState<boolean>(false);
   const [garden, setGarden] = useState<GardenKeys | undefined>([]);
+  const [waterGarden, setWaterGarden] = useState<boolean>(false);
   const [isGardenView, setIsGardenView] = useState<boolean>(true);
   const [bullDoze, setBullDoze] = useState<boolean>(false);
   const [filterGarden, setFilterGarden] = useState<boolean>(false);
@@ -94,10 +95,10 @@ const Main = () => {
               <Sidebar modal={modal} setModal={setModal} />
               {
                 isGardenView
-                ? <Grid popUp={popUp} setPopUp={setPopUp} fullClear={fullClear} setFullClear={setFullClear} setPartialClear={setPartialClear} reset={reset} alert={alert} setAlert={setAlert} modal={modal} setModal={setModal} garden={garden} setGarden={setGarden} bullDoze={bullDoze} setBullDoze={setBullDoze} filterGarden={filterGarden} setFilterGarden={setFilterGarden} />
+                ? <Grid popUp={popUp} setPopUp={setPopUp} fullClear={fullClear} setFullClear={setFullClear} setPartialClear={setPartialClear} reset={reset} alert={alert} setAlert={setAlert} modal={modal} setModal={setModal} garden={garden} setGarden={setGarden} waterGarden={waterGarden} bullDoze={bullDoze} setBullDoze={setBullDoze} filterGarden={filterGarden} setFilterGarden={setFilterGarden} />
                 : <List garden={garden} />
               }
-              <Nav reset={reset} handleFullClear={handleFullClear} handlePartialClear={handlePartialClear} isGardenView={isGardenView} setIsGardenView={setIsGardenView} />
+              <Nav reset={reset} waterGarden={waterGarden} setWaterGarden={setWaterGarden} handleFullClear={handleFullClear} handlePartialClear={handlePartialClear} isGardenView={isGardenView} setIsGardenView={setIsGardenView} />
             </>
             : <div className="mobile-message">
                 Please switch to a larger device to use this app.

--- a/src/components/Nav/Nav.tsx
+++ b/src/components/Nav/Nav.tsx
@@ -2,13 +2,15 @@ import './Nav.scss';
 
 type NavProps = {
   reset: Function;
+  waterGarden: boolean;
+  setWaterGarden: Function;
   handleFullClear: () => void;
   handlePartialClear: () => void;
   isGardenView: boolean;
   setIsGardenView: Function;
 }
 
-const Nav = ({ reset, handleFullClear, handlePartialClear, isGardenView, setIsGardenView }: NavProps) => {
+const Nav = ({ reset, waterGarden, setWaterGarden, handleFullClear, handlePartialClear, isGardenView, setIsGardenView }: NavProps) => {
 
   const toggleView = (): void => {
     setIsGardenView(!isGardenView);
@@ -16,7 +18,7 @@ const Nav = ({ reset, handleFullClear, handlePartialClear, isGardenView, setIsGa
   }
 
   const handleWaterAll = (): void => {
-    console.log('watered yo')
+    setWaterGarden(!waterGarden)
   }
 
   return (


### PR DESCRIPTION
## What I did:
Hooked up FE watering functionality!
If a planted plant has elapsed its watering schedule, it will now pulse orange letting the user know it needs attention.
If you click on a cell and click the "Water!" button, it resets the `updated_at` field on the backend and return the border to green.
Clicking the Water All Plants watering can in the Nav section waters ALL plants.

### Testing notes:
- For testing purposes, I have an abbreviated mock watering schedule uncommented out currently that sets each watering schedule to:
  - Minimum: 1 hour
  - Average: 1 minute
  - Frequent: 1 second (Granny Smith Apple has "Frequent" watering, meaning it should be pulsing again immediately after refreshing the page)
    - Ensure that the timezone offset is working for where you're at, because I was running into some oddities there too...
- Do multiple tests on clicking the "Water!" button on individual cells
  - Occasionally I'm seeing the PATCHes fail to fire, and I'm not really sure why.  It may be due to the pulsing scale, since I haven't seen the PATCHes fail on the water entire garden function.
- Have a diverse garden of disabled, placed, and planted items as you test out the water entire garden feature

## Did this break anything?
- [ ] No
- [ ] Yes

## Type of change

- [ ] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor(DRY-ing up/ reorganizing code, etc.)
- [ ] Super small fix (Corrected a typo, removed a comment, etc.)
- [ ] Skip all the other stuff and briefly explain the fix.

## Checklist:
- [ ] If this code needs to be tested, all tests are passing
- [ ] The code runs locally
- [ ] There are comments where clarification/ organization is needed
- [ ] The code is DRY. If it's not, I tried my best
- [ ] I reviewed my code before pushing

## What's next?
