### PR TITLE
Feature/dynamic watering

### DIFF
--- a/src/apiCalls.tsx
+++ b/src/apiCalls.tsx
@@ -61,7 +61,7 @@ const WATERING_MAP: WateringType = {
   'Frequent': 3
 }
 
-const patchCellContents = ({plant}: CellContents, id: string, status: keyof StatusType, watering: keyof WateringType, setter: Function) => {
+const patchCellContents = ({plant}: CellContents, id: string, status: keyof StatusType, watering: keyof WateringType) => {
   return fetch(`https://backyarder-be-47454958a7d2.herokuapp.com/api/v1/cell`, {
             method: 'PATCH',
             body: JSON.stringify({
@@ -77,7 +77,7 @@ const patchCellContents = ({plant}: CellContents, id: string, status: keyof Stat
             }
           })
           .then(res => handleError(res))
-          .then(data => setter(data.data.attributes["updated_at"]))
+          // .then(data => setter(data.data.attributes["updated_at"]))
 }
 
 const patchDisabledOrRemoved = (id: string, status: keyof StatusType) => {

--- a/src/apiCalls.tsx
+++ b/src/apiCalls.tsx
@@ -61,7 +61,7 @@ const WATERING_MAP: WateringType = {
   'Frequent': 3
 }
 
-const patchCellContents = ({plant}: CellContents, id: string, status: keyof StatusType, watering: keyof WateringType) => {
+const patchCellContents = ({plant}: CellContents, id: string, status: keyof StatusType, watering: keyof WateringType, setter: Function) => {
   return fetch(`https://backyarder-be-47454958a7d2.herokuapp.com/api/v1/cell`, {
             method: 'PATCH',
             body: JSON.stringify({
@@ -77,6 +77,7 @@ const patchCellContents = ({plant}: CellContents, id: string, status: keyof Stat
             }
           })
           .then(res => handleError(res))
+          .then(data => setter(data.data.attributes["updated_at"]))
 }
 
 const patchDisabledOrRemoved = (id: string, status: keyof StatusType) => {
@@ -87,6 +88,7 @@ const patchDisabledOrRemoved = (id: string, status: keyof StatusType) => {
               location_id: id,
               image: null,
               status: STATUS_MAP[`${status}`],
+              watering: 'None',
               plant_id: null
             }),
             headers: {

--- a/src/components/Cell/Cell.tsx
+++ b/src/components/Cell/Cell.tsx
@@ -57,7 +57,7 @@ const Cell = ({ id, garden, setGarden, waterGarden, bullDoze, setBullDoze, filte
         setIsPlanted(true);
       }
       if (foundCell && foundCell.updated_at) {
-        setLastUpdate(foundCell.updated_at);
+        handleUpdate(foundCell.location_id, foundCell.updated_at);
       }
     }
     // eslint-disable-next-line
@@ -66,9 +66,9 @@ const Cell = ({ id, garden, setGarden, waterGarden, bullDoze, setBullDoze, filte
   useEffect(() => {
     if (isPlanted && cellContents && cellContents.plant.watering && cellContents.plant.watering !== 'None' && typeof cellContents.plant.updated_at !== 'undefined') {
       let now = Date.now() + (new Date().getTimezoneOffset() * 60 * 1000);
-      let lastUpdateAdjusted = convertTime(lastUpdate);
+      let lastUpdateAdjusted = convertTime(lastUpdate[cellContents.plant.location_id]);
       let interval = WATERING_SCHEDULE[cellContents?.plant.watering] * 24 * 60 * 60 * 1000;
-      // console.log('now', new Date(now), 'last', new Date(lastUpdateAdjusted))
+      console.log('now', new Date(now), 'last', new Date(lastUpdateAdjusted))
       if ((now - lastUpdateAdjusted) >= interval) {
         setNeedsWatering(true);
       }
@@ -205,6 +205,13 @@ const Cell = ({ id, garden, setGarden, waterGarden, bullDoze, setBullDoze, filte
       };
       return newState;
     });
+  }
+
+  const handleUpdate = (key: string, value: string) => {
+    setLastUpdate((prevState: {}) => ({
+      ...prevState,
+      [key]: value,
+    }));
   }
 
   const handleTime = () => {

--- a/src/components/Cell/Cell.tsx
+++ b/src/components/Cell/Cell.tsx
@@ -27,7 +27,7 @@ const WATERING_SCHEDULE = {
   'Frequent': 1 / (24 * 60 * 60) // 1sec
 }
 
-const Cell = ({ id, garden, setGarden, waterGarden, bullDoze, setBullDoze, filterGarden, setFilterGarden, toggleModal }: GridCell) => {
+const Cell = ({ id, garden, setGarden, waterGarden, bullDoze, setBullDoze, filterGarden, setFilterGarden, toggleModal, lastUpdate, setLastUpdate }: GridCell) => {
   // eslint-disable-next-line
   const [apiError, setApiError] = useState<string>('');
   const [cellContents, setCellContents] = useState<CellContents | undefined>();
@@ -41,7 +41,6 @@ const Cell = ({ id, garden, setGarden, waterGarden, bullDoze, setBullDoze, filte
   const [isPopulated, setIsPopulated] = useState<boolean>(false);
   const [needsUpdate, setNeedsUpdate] = useState<(keyof StatusType)>();
   const [shouldRender, setShouldRender] = useState<boolean>(false);
-  const [lastUpdate, setLastUpdate] = useState<string>('');
 
   useEffect(() => {
     if (garden) {
@@ -69,6 +68,7 @@ const Cell = ({ id, garden, setGarden, waterGarden, bullDoze, setBullDoze, filte
       let now = Date.now() + (new Date().getTimezoneOffset() * 60 * 1000);
       let lastUpdateAdjusted = convertTime(lastUpdate);
       let interval = WATERING_SCHEDULE[cellContents?.plant.watering] * 24 * 60 * 60 * 1000;
+      // console.log('now', new Date(now), 'last', new Date(lastUpdateAdjusted))
       if ((now - lastUpdateAdjusted) >= interval) {
         setNeedsWatering(true);
       }

--- a/src/components/Cell/Cell.tsx
+++ b/src/components/Cell/Cell.tsx
@@ -217,7 +217,7 @@ const Cell = ({ id, garden, setGarden, waterGarden, bullDoze, setBullDoze, filte
   }
 
   const convertTime = (dateString: string) => {
-    let [datePart, timePart] = dateString.split('  ');
+    let [datePart, timePart] = dateString.charAt(11) === ' ' ? dateString.split('  ') : dateString.split(' ');
     let [month, day, year] = datePart.split('/').map(Number);
     let [hours, minutes] = timePart.split(':').map(Number);
     let timestamp = new Date(year, month - 1, day, hours, minutes).getTime();

--- a/src/components/Cell/Cell.tsx
+++ b/src/components/Cell/Cell.tsx
@@ -57,7 +57,8 @@ const Cell = ({ id, garden, setGarden, waterGarden, bullDoze, setBullDoze, filte
         setIsPlanted(true);
       }
       if (foundCell && foundCell.updated_at) {
-        handleUpdate(foundCell.location_id, foundCell.updated_at);
+        let updateValue = convertTime(lastUpdate[foundCell.location_id]) > convertTime(foundCell.updated_at) ? lastUpdate[foundCell.location_id] : foundCell.updated_at;
+        handleUpdate(foundCell.location_id, updateValue);
       }
     }
     // eslint-disable-next-line
@@ -86,7 +87,7 @@ const Cell = ({ id, garden, setGarden, waterGarden, bullDoze, setBullDoze, filte
 
   useEffect(() => {
     if (cellContents && needsUpdate) {
-      patchCellContents(cellContents, id, needsUpdate, cellContents.plant.watering, setLastUpdate)
+      patchCellContents(cellContents, id, needsUpdate, cellContents.plant.watering)
         .catch((err) => {
           handleApiError(err);
         });
@@ -240,9 +241,9 @@ const Cell = ({ id, garden, setGarden, waterGarden, bullDoze, setBullDoze, filte
   const handleWatered = async () => {
     if (cellContents && cellContents.plant.watering && cellContents.plant.watering !== 'None') {
       try {
-        await patchCellContents(cellContents, id, 'placed', cellContents.plant.watering, setLastUpdate)
-        await patchCellContents(cellContents, id, 'locked', cellContents.plant.watering, setLastUpdate)
-        setLastUpdate(handleTime());
+        await patchCellContents(cellContents, id, 'placed', cellContents.plant.watering)
+        await patchCellContents(cellContents, id, 'locked', cellContents.plant.watering)
+        handleUpdate(cellContents.plant.location_id, handleTime());
         setNeedsWatering(false);
         let interval = WATERING_SCHEDULE[cellContents.plant.watering] * 24 * 60 * 60 * 1000;
         setTimeout(() => {

--- a/src/components/Cell/Cell.tsx
+++ b/src/components/Cell/Cell.tsx
@@ -30,8 +30,6 @@ const WATERING_SCHEDULE = {
 const Cell = ({ id, garden, setGarden, waterGarden, bullDoze, setBullDoze, filterGarden, setFilterGarden, toggleModal }: GridCell) => {
   // eslint-disable-next-line
   const [apiError, setApiError] = useState<string>('');
-  // eslint-disable-next-line
-  const [cell, setCell] = useState<CellKeys | undefined>();
   const [cellContents, setCellContents] = useState<CellContents | undefined>();
   const [className, setClassName] = useState<string>('cell');
   const [isClicked, setIsClicked] = useState<boolean>(false);
@@ -58,8 +56,6 @@ const Cell = ({ id, garden, setGarden, waterGarden, bullDoze, setBullDoze, filte
         setIsPopulated(true);
         setIsPlanted(true);
       }
-
-      setCell(foundCell);
     }
     // eslint-disable-next-line
   }, []);
@@ -70,7 +66,7 @@ const Cell = ({ id, garden, setGarden, waterGarden, bullDoze, setBullDoze, filte
       const daysToAdd = WATERING_SCHEDULE[cellContents?.plant.watering]
       const nextWatering = new Date(cellContents?.plant.updated_at).getTime() + (daysToAdd * 24 * 60 * 60 * 1000)
       console.log(cellContents?.plant.updated_at)
-      console.log(today, nextWatering)
+      console.log('today', today, 'nextwatering', nextWatering)
       if (today > nextWatering) {
         setNeedsWatering(true);
       }
@@ -224,6 +220,7 @@ const Cell = ({ id, garden, setGarden, waterGarden, bullDoze, setBullDoze, filte
     setCellContents(undefined);
     handleNeedsUpdating('empty');
     setShouldRender(true);
+    setNeedsWatering(false);
   }
 
   const handleCloseModal = () => {
@@ -254,6 +251,7 @@ const Cell = ({ id, garden, setGarden, waterGarden, bullDoze, setBullDoze, filte
     setCellContents(undefined);
     setIsPopulated(false);
     setIsPlanted(false);
+    setNeedsWatering(false);
   }
 
   const handleUnplanted = (): void => {

--- a/src/components/Cell/Cell.tsx
+++ b/src/components/Cell/Cell.tsx
@@ -27,7 +27,7 @@ const WATERING_SCHEDULE = {
   'Frequent': 1 / (24 * 60 * 60) // 1sec
 }
 
-const Cell = ({ id, garden, setGarden, waterGarden, bullDoze, setBullDoze, filterGarden, setFilterGarden, toggleModal, isToggled }: GridCell) => {
+const Cell = ({ id, garden, setGarden, waterGarden, bullDoze, setBullDoze, filterGarden, setFilterGarden, toggleModal }: GridCell) => {
   // eslint-disable-next-line
   const [apiError, setApiError] = useState<string>('');
   const [cellContents, setCellContents] = useState<CellContents | undefined>();
@@ -67,7 +67,7 @@ const Cell = ({ id, garden, setGarden, waterGarden, bullDoze, setBullDoze, filte
   useEffect(() => {
     if (isPlanted && cellContents && cellContents.plant.watering && cellContents.plant.watering !== 'None' && typeof cellContents.plant.updated_at !== 'undefined') {
       let now = Date.now() + (new Date().getTimezoneOffset() * 60 * 1000);
-      let lastUpdateAdjusted = isToggled ? convertTime(lastUpdate) + (new Date().getTimezoneOffset() * 60 * 1000) : convertTime(lastUpdate);
+      let lastUpdateAdjusted = convertTime(lastUpdate);
       let interval = WATERING_SCHEDULE[cellContents?.plant.watering] * 24 * 60 * 60 * 1000;
       if ((now - lastUpdateAdjusted) >= interval) {
         setNeedsWatering(true);
@@ -76,6 +76,7 @@ const Cell = ({ id, garden, setGarden, waterGarden, bullDoze, setBullDoze, filte
         setNeedsWatering(true);
       }, interval - (now-lastUpdateAdjusted));
     }
+    // eslint-disable-next-line
   }, [cellContents, isPlanted])
 
   useEffect(() => {

--- a/src/components/Cell/Cell.tsx
+++ b/src/components/Cell/Cell.tsx
@@ -63,7 +63,7 @@ const Cell = ({ id, garden, setGarden, waterGarden, bullDoze, setBullDoze, filte
     }
     // eslint-disable-next-line
   }, []);
-  
+
   useEffect(() => {
     if (isPlanted && cellContents && cellContents.plant.watering && cellContents.plant.watering !== 'None' && typeof cellContents.plant.updated_at !== 'undefined') {
       let now = Date.now() + (new Date().getTimezoneOffset() * 60 * 1000);
@@ -207,7 +207,7 @@ const Cell = ({ id, garden, setGarden, waterGarden, bullDoze, setBullDoze, filte
   }
 
   const handleTime = () => {
-    let now = new Date();
+    let now = new Date(Date.now() + new Date().getTimezoneOffset() * 60 * 1000);
     let year = now.getFullYear();
     let month = String(now.getMonth() + 1).padStart(2, '0');
     let day = String(now.getDate()).padStart(2, '0');

--- a/src/components/Cell/Cell.tsx
+++ b/src/components/Cell/Cell.tsx
@@ -69,7 +69,6 @@ const Cell = ({ id, garden, setGarden, waterGarden, bullDoze, setBullDoze, filte
       let now = Date.now() + (new Date().getTimezoneOffset() * 60 * 1000);
       let lastUpdateAdjusted = convertTime(lastUpdate[cellContents.plant.location_id]);
       let interval = WATERING_SCHEDULE[cellContents?.plant.watering] * 24 * 60 * 60 * 1000;
-      console.log('now', new Date(now), 'last', new Date(lastUpdateAdjusted))
       if ((now - lastUpdateAdjusted) >= interval) {
         setNeedsWatering(true);
       }

--- a/src/components/Grid/Grid.tsx
+++ b/src/components/Grid/Grid.tsx
@@ -76,7 +76,7 @@ const Grid = ({ popUp, setPopUp, fullClear, setFullClear, setPartialClear, reset
       />
     );
   });
-  console.log(garden)
+
   return (
     <section id='grid'>
       {cells}

--- a/src/components/Grid/Grid.tsx
+++ b/src/components/Grid/Grid.tsx
@@ -15,6 +15,8 @@ export interface GridProps {
   setBullDoze: Function;
   filterGarden: boolean;
   setFilterGarden: Function;
+  lastUpdate: string;
+  setLastUpdate: Function;
 }
 
 interface AdditionalProps {
@@ -42,7 +44,7 @@ export type CellKeys = {
   updated_at: string | undefined;
 }
 
-const Grid = ({ popUp, setPopUp, fullClear, setFullClear, setPartialClear, reset, alert, setAlert, modal, setModal, garden, setGarden, waterGarden, bullDoze, setBullDoze, filterGarden, setFilterGarden }: CombinedProps) => {
+const Grid = ({ popUp, setPopUp, fullClear, setFullClear, setPartialClear, reset, alert, setAlert, modal, setModal, garden, setGarden, waterGarden, bullDoze, setBullDoze, filterGarden, setFilterGarden, lastUpdate, setLastUpdate }: CombinedProps) => {
 
   useEffect(() => {
     if (alert) {
@@ -73,6 +75,8 @@ const Grid = ({ popUp, setPopUp, fullClear, setFullClear, setPartialClear, reset
         filterGarden={filterGarden}
         setFilterGarden={setFilterGarden}
         toggleModal={toggleModal}
+        lastUpdate={lastUpdate}
+        setLastUpdate={setLastUpdate}
       />
     );
   });

--- a/src/components/Grid/Grid.tsx
+++ b/src/components/Grid/Grid.tsx
@@ -15,6 +15,7 @@ export interface GridProps {
   setBullDoze: Function;
   filterGarden: boolean;
   setFilterGarden: Function;
+  isToggled: boolean;
 }
 
 interface AdditionalProps {
@@ -39,10 +40,10 @@ export type CellKeys = {
   plant_id: number | undefined;
   watering: keyof WateringType
   status: string | number | null | undefined;
-  updated_at: number | undefined;
+  updated_at: string | undefined;
 }
 
-const Grid = ({ popUp, setPopUp, fullClear, setFullClear, setPartialClear, reset, alert, setAlert, modal, setModal, garden, setGarden, waterGarden, bullDoze, setBullDoze, filterGarden, setFilterGarden }: CombinedProps) => {
+const Grid = ({ popUp, setPopUp, fullClear, setFullClear, setPartialClear, reset, alert, setAlert, modal, setModal, garden, setGarden, waterGarden, bullDoze, setBullDoze, filterGarden, setFilterGarden, isToggled }: CombinedProps) => {
 
   useEffect(() => {
     if (alert) {
@@ -73,6 +74,7 @@ const Grid = ({ popUp, setPopUp, fullClear, setFullClear, setPartialClear, reset
         filterGarden={filterGarden}
         setFilterGarden={setFilterGarden}
         toggleModal={toggleModal}
+        isToggled={isToggled}
       />
     );
   });

--- a/src/components/Grid/Grid.tsx
+++ b/src/components/Grid/Grid.tsx
@@ -15,7 +15,6 @@ export interface GridProps {
   setBullDoze: Function;
   filterGarden: boolean;
   setFilterGarden: Function;
-  isToggled: boolean;
 }
 
 interface AdditionalProps {
@@ -43,7 +42,7 @@ export type CellKeys = {
   updated_at: string | undefined;
 }
 
-const Grid = ({ popUp, setPopUp, fullClear, setFullClear, setPartialClear, reset, alert, setAlert, modal, setModal, garden, setGarden, waterGarden, bullDoze, setBullDoze, filterGarden, setFilterGarden, isToggled }: CombinedProps) => {
+const Grid = ({ popUp, setPopUp, fullClear, setFullClear, setPartialClear, reset, alert, setAlert, modal, setModal, garden, setGarden, waterGarden, bullDoze, setBullDoze, filterGarden, setFilterGarden }: CombinedProps) => {
 
   useEffect(() => {
     if (alert) {
@@ -74,7 +73,6 @@ const Grid = ({ popUp, setPopUp, fullClear, setFullClear, setPartialClear, reset
         filterGarden={filterGarden}
         setFilterGarden={setFilterGarden}
         toggleModal={toggleModal}
-        isToggled={isToggled}
       />
     );
   });

--- a/src/components/Grid/Grid.tsx
+++ b/src/components/Grid/Grid.tsx
@@ -1,7 +1,7 @@
 import { useEffect } from 'react';
 import Cell from '../Cell/Cell';
 import Modal from '../Modal/Modal';
-import { GardenKeys } from '../Main/Main';
+import { GardenKeys, lastUpdateType } from '../Main/Main';
 import { cellIDs } from './cellIDs';
 import './Grid.scss';
 import ConfirmModal from '../ConfirmModal/ConfirmModal';
@@ -15,7 +15,7 @@ export interface GridProps {
   setBullDoze: Function;
   filterGarden: boolean;
   setFilterGarden: Function;
-  lastUpdate: string;
+  lastUpdate: lastUpdateType;
   setLastUpdate: Function;
 }
 

--- a/src/components/Main/Main.tsx
+++ b/src/components/Main/Main.tsx
@@ -29,6 +29,7 @@ const Main = () => {
   const [isDesktop, setIsDesktop] = useState<boolean>(true);
   // eslint-disable-next-line
   const [apiError, setApiError] = useState<string>('');
+  const [lastUpdate, setLastUpdate] = useState<string>('');
 
   useEffect(() => {
     const checkScreenSize = () => {
@@ -95,7 +96,7 @@ const Main = () => {
               <Sidebar modal={modal} setModal={setModal} />
               {
                 isGardenView
-                ? <Grid popUp={popUp} setPopUp={setPopUp} fullClear={fullClear} setFullClear={setFullClear} setPartialClear={setPartialClear} reset={reset} alert={alert} setAlert={setAlert} modal={modal} setModal={setModal} garden={garden} setGarden={setGarden} waterGarden={waterGarden} bullDoze={bullDoze} setBullDoze={setBullDoze} filterGarden={filterGarden} setFilterGarden={setFilterGarden} />
+                ? <Grid popUp={popUp} setPopUp={setPopUp} fullClear={fullClear} setFullClear={setFullClear} setPartialClear={setPartialClear} reset={reset} alert={alert} setAlert={setAlert} modal={modal} setModal={setModal} garden={garden} setGarden={setGarden} waterGarden={waterGarden} bullDoze={bullDoze} setBullDoze={setBullDoze} filterGarden={filterGarden} setFilterGarden={setFilterGarden} lastUpdate={lastUpdate} setLastUpdate={setLastUpdate}/>
                 : <List garden={garden} />
               }
               <Nav reset={reset} waterGarden={waterGarden} setWaterGarden={setWaterGarden} handleFullClear={handleFullClear} handlePartialClear={handlePartialClear} isGardenView={isGardenView} setIsGardenView={setIsGardenView} />

--- a/src/components/Main/Main.tsx
+++ b/src/components/Main/Main.tsx
@@ -29,7 +29,6 @@ const Main = () => {
   const [isDesktop, setIsDesktop] = useState<boolean>(true);
   // eslint-disable-next-line
   const [apiError, setApiError] = useState<string>('');
-  const [isToggled, setIsToggled] = useState<boolean>(false);
 
   useEffect(() => {
     const checkScreenSize = () => {
@@ -96,10 +95,10 @@ const Main = () => {
               <Sidebar modal={modal} setModal={setModal} />
               {
                 isGardenView
-                ? <Grid popUp={popUp} setPopUp={setPopUp} fullClear={fullClear} setFullClear={setFullClear} setPartialClear={setPartialClear} reset={reset} alert={alert} setAlert={setAlert} modal={modal} setModal={setModal} garden={garden} setGarden={setGarden} waterGarden={waterGarden} bullDoze={bullDoze} setBullDoze={setBullDoze} filterGarden={filterGarden} setFilterGarden={setFilterGarden} isToggled={isToggled} />
+                ? <Grid popUp={popUp} setPopUp={setPopUp} fullClear={fullClear} setFullClear={setFullClear} setPartialClear={setPartialClear} reset={reset} alert={alert} setAlert={setAlert} modal={modal} setModal={setModal} garden={garden} setGarden={setGarden} waterGarden={waterGarden} bullDoze={bullDoze} setBullDoze={setBullDoze} filterGarden={filterGarden} setFilterGarden={setFilterGarden} />
                 : <List garden={garden} />
               }
-              <Nav reset={reset} waterGarden={waterGarden} setWaterGarden={setWaterGarden} handleFullClear={handleFullClear} handlePartialClear={handlePartialClear} isGardenView={isGardenView} setIsGardenView={setIsGardenView} setIsToggled={setIsToggled} />
+              <Nav reset={reset} waterGarden={waterGarden} setWaterGarden={setWaterGarden} handleFullClear={handleFullClear} handlePartialClear={handlePartialClear} isGardenView={isGardenView} setIsGardenView={setIsGardenView} />
             </>
             : <div className="mobile-message">
                 Please switch to a larger device to use this app.

--- a/src/components/Main/Main.tsx
+++ b/src/components/Main/Main.tsx
@@ -70,6 +70,7 @@ const Main = () => {
         (lastUpdate as Record<string, string>)[key] = '10/10/2000 10:10';
       }
     }
+    // eslint-disable-next-line
   }, []);
 
   const handleApiError = (error: string) => {

--- a/src/components/Main/Main.tsx
+++ b/src/components/Main/Main.tsx
@@ -26,9 +26,10 @@ const Main = () => {
   const [fullClear, setFullClear] = useState<boolean>(false);
   // eslint-disable-next-line
   const [partialClear, setPartialClear] = useState<boolean>(false);
-  const [isDesktop, setIsDesktop] = useState<boolean>(true)
+  const [isDesktop, setIsDesktop] = useState<boolean>(true);
   // eslint-disable-next-line
-  const [apiError, setApiError] = useState<string>('')
+  const [apiError, setApiError] = useState<string>('');
+  const [isToggled, setIsToggled] = useState<boolean>(false);
 
   useEffect(() => {
     const checkScreenSize = () => {
@@ -95,10 +96,10 @@ const Main = () => {
               <Sidebar modal={modal} setModal={setModal} />
               {
                 isGardenView
-                ? <Grid popUp={popUp} setPopUp={setPopUp} fullClear={fullClear} setFullClear={setFullClear} setPartialClear={setPartialClear} reset={reset} alert={alert} setAlert={setAlert} modal={modal} setModal={setModal} garden={garden} setGarden={setGarden} waterGarden={waterGarden} bullDoze={bullDoze} setBullDoze={setBullDoze} filterGarden={filterGarden} setFilterGarden={setFilterGarden} />
+                ? <Grid popUp={popUp} setPopUp={setPopUp} fullClear={fullClear} setFullClear={setFullClear} setPartialClear={setPartialClear} reset={reset} alert={alert} setAlert={setAlert} modal={modal} setModal={setModal} garden={garden} setGarden={setGarden} waterGarden={waterGarden} bullDoze={bullDoze} setBullDoze={setBullDoze} filterGarden={filterGarden} setFilterGarden={setFilterGarden} isToggled={isToggled} />
                 : <List garden={garden} />
               }
-              <Nav reset={reset} waterGarden={waterGarden} setWaterGarden={setWaterGarden} handleFullClear={handleFullClear} handlePartialClear={handlePartialClear} isGardenView={isGardenView} setIsGardenView={setIsGardenView} />
+              <Nav reset={reset} waterGarden={waterGarden} setWaterGarden={setWaterGarden} handleFullClear={handleFullClear} handlePartialClear={handlePartialClear} isGardenView={isGardenView} setIsGardenView={setIsGardenView} setIsToggled={setIsToggled} />
             </>
             : <div className="mobile-message">
                 Please switch to a larger device to use this app.

--- a/src/components/Main/Main.tsx
+++ b/src/components/Main/Main.tsx
@@ -14,6 +14,10 @@ type GetGardenKeys = {
   attributes: CellKeys[]
 }
 
+export type lastUpdateType = {
+  [key: string]: string;
+}
+
 const Main = () => {
   const [alert, setAlert] = useState<boolean>(false);
   const [modal, setModal] = useState<boolean>(false);
@@ -29,7 +33,7 @@ const Main = () => {
   const [isDesktop, setIsDesktop] = useState<boolean>(true);
   // eslint-disable-next-line
   const [apiError, setApiError] = useState<string>('');
-  const [lastUpdate, setLastUpdate] = useState<string>('');
+  const [lastUpdate, setLastUpdate] = useState<lastUpdateType>({});
 
   useEffect(() => {
     const checkScreenSize = () => {
@@ -57,6 +61,15 @@ const Main = () => {
       .catch((err) => {
         handleApiError(err)
       })
+  }, []);
+
+  useEffect(() => {
+    for (let letter = 'A'.charCodeAt(0); letter <= 'J'.charCodeAt(0); letter++) {
+      for (let number = 1; number <= 10; number++) {
+        const key = String.fromCharCode(letter) + number;
+        (lastUpdate as Record<string, string>)[key] = 'string';
+      }
+    }
   }, []);
 
   const handleApiError = (error: string) => {

--- a/src/components/Main/Main.tsx
+++ b/src/components/Main/Main.tsx
@@ -67,7 +67,7 @@ const Main = () => {
     for (let letter = 'A'.charCodeAt(0); letter <= 'J'.charCodeAt(0); letter++) {
       for (let number = 1; number <= 10; number++) {
         const key = String.fromCharCode(letter) + number;
-        (lastUpdate as Record<string, string>)[key] = 'string';
+        (lastUpdate as Record<string, string>)[key] = '10/10/2000 10:10';
       }
     }
   }, []);

--- a/src/components/Nav/Nav.tsx
+++ b/src/components/Nav/Nav.tsx
@@ -8,10 +8,9 @@ type NavProps = {
   handlePartialClear: () => void;
   isGardenView: boolean;
   setIsGardenView: Function;
-  setIsToggled: Function;
 }
 
-const Nav = ({ reset, waterGarden, setWaterGarden, handleFullClear, handlePartialClear, isGardenView, setIsGardenView, setIsToggled }: NavProps) => {
+const Nav = ({ reset, waterGarden, setWaterGarden, handleFullClear, handlePartialClear, isGardenView, setIsGardenView }: NavProps) => {
 
   const toggleView = (): void => {
     setIsGardenView(!isGardenView);
@@ -42,10 +41,7 @@ const Nav = ({ reset, waterGarden, setWaterGarden, handleFullClear, handlePartia
           cursor: isGardenView ? 'auto' : 'pointer'
         }}
         disabled={isGardenView}
-        onClick={() => {
-          setIsToggled(true);
-          toggleView();
-        }}
+        onClick={toggleView}
       >
         <span className="material-symbols-rounded nav-icon">outdoor_garden</span>GARDEN VIEW
       </button>

--- a/src/components/Nav/Nav.tsx
+++ b/src/components/Nav/Nav.tsx
@@ -8,9 +8,10 @@ type NavProps = {
   handlePartialClear: () => void;
   isGardenView: boolean;
   setIsGardenView: Function;
+  setIsToggled: Function;
 }
 
-const Nav = ({ reset, waterGarden, setWaterGarden, handleFullClear, handlePartialClear, isGardenView, setIsGardenView }: NavProps) => {
+const Nav = ({ reset, waterGarden, setWaterGarden, handleFullClear, handlePartialClear, isGardenView, setIsGardenView, setIsToggled }: NavProps) => {
 
   const toggleView = (): void => {
     setIsGardenView(!isGardenView);
@@ -41,7 +42,10 @@ const Nav = ({ reset, waterGarden, setWaterGarden, handleFullClear, handlePartia
           cursor: isGardenView ? 'auto' : 'pointer'
         }}
         disabled={isGardenView}
-        onClick={toggleView}
+        onClick={() => {
+          setIsToggled(true);
+          toggleView();
+        }}
       >
         <span className="material-symbols-rounded nav-icon">outdoor_garden</span>GARDEN VIEW
       </button>


### PR DESCRIPTION
## What I did:
- Added dynamic watering alerts accurate to the minute (unfortunately not to the second unless we make adjustments on the backend"

## Test Notes:
- Test 1:
  - Plant a Prickly Cycad, and wait out the full 60 seconds for the pulsating orange alert to pop up.

- Test 2:
  - At the beginning of a new minute (ideally within the first 10 seconds), plant a Prickly Cycad. Partway through the watering interval, refresh the page and/or toggle between list/garden view. You should notice that the cell will pulsate orange once the new minute is reached, rather than after a full 60 seconds. This is because on the backend, our "updated_at" attribute does not include seconds. So, our alerts will only be accurate to the minute upon page refresh / view toggle.

## Issues closed:
#137 

## Did this break anything?
- [x] No
- [ ] Yes

## Type of change

- [x] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor(DRY-ing up/ reorganizing code, etc.)
- [ ] Super small fix (Corrected a typo, removed a comment, etc.)
- [ ] Skip all the other stuff and briefly explain the fix.

## Checklist:
- [ ] If this code needs to be tested, all tests are passing
- [x] The code runs locally
- [ ] There are comments where clarification/ organization is needed
- [ ] The code is DRY. If it's not, I tried my best
- [x] I reviewed my code before pushing

## What's next?
