### PR TITLE
Allow persistence of disabled cells despite page refresh or view toggle

### DIFF
--- a/src/components/Main/Main.tsx
+++ b/src/components/Main/Main.tsx
@@ -15,7 +15,10 @@ type GetGardenKeys = {
 }
 
 export type lastUpdateType = {
-  [key: string]: string;
+  [key: string]: {
+    updatedAt: string;
+    status: string;
+  };
 }
 
 export type WishlistType = {
@@ -73,7 +76,10 @@ const Main = () => {
     for (let letter = 'A'.charCodeAt(0); letter <= 'J'.charCodeAt(0); letter++) {
       for (let number = 1; number <= 10; number++) {
         const key = String.fromCharCode(letter) + number;
-        (lastUpdate as Record<string, string>)[key] = '10/10/2000 10:10';
+        (lastUpdate as lastUpdateType)[key] = {
+          updatedAt: '10/10/2000 10:10',
+          status: 'empty'
+        };
       }
     }
     // eslint-disable-next-line


### PR DESCRIPTION
## What I did:
- Fixed a bug where disabling a cell, then refreshing the page, then enabling the cell, then toggling between views would incorrectly display the cell's status

## Testing Notes:
- Disable a cell. Refresh the page. Enable the cell. Toggle between List View and back to Grid View. The cell should be enabled, not disabled.

## Issues closed:

## Did this break anything?
- [x] No
- [ ] Yes

## Type of change

- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor(DRY-ing up/ reorganizing code, etc.)
- [ ] Super small fix (Corrected a typo, removed a comment, etc.)
- [ ] Skip all the other stuff and briefly explain the fix.

## Checklist:
- [ ] If this code needs to be tested, all tests are passing
- [x] The code runs locally
- [ ] There are comments where clarification/ organization is needed
- [ ] The code is DRY. If it's not, I tried my best
- [x] I reviewed my code before pushing

## What's next?
